### PR TITLE
Remove maximum-scale setting.

### DIFF
--- a/react_ws_src/static/index.html
+++ b/react_ws_src/static/index.html
@@ -11,7 +11,7 @@
 	<meta http-equiv="x-ua-compatible" content="ie=edge" />
 	<title>X tic tac toe multiplayer demo</title>
 	<meta name="Description" content="X-ttt built with React and Webpack, React-router, Babel, Ampersand on Node.js/Express/Socket.io" />
-	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
 
 
 	<!-- STYLESHEETS -->


### PR DESCRIPTION
Removing `maximum-scale=1` from the meta-viewpoint element prevents zooming from being disabled on some devices.

Fixes https://github.com/xydlebug/X-ttt/issues/4